### PR TITLE
Autobuild Maintenance

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,22 +1,29 @@
 # Maintainer: Bennett Goble <nivardus@gmail.com>
+# Partial Maintainer: Alex Tharp <toastercup@gmail.com>
 
 pkgname=autobuild
-pkgver=0.8.12
+pkgver=1.0.1
 pkgrel=1
 pkgdesc='Linden Lab Automated Package Management and Build System'
 arch=('any')
 url='http://wiki.secondlife.com/wiki/Autobuild'
 license=('MIT')
-depends=('python2')
-makedepends=('python2-distribute')
+depends=('python2' 'python2-pydot' 'llbase')
+makedepends=('python2-setuptools')
 source=(http://pypi.python.org/packages/source/a/autobuild/autobuild-${pkgver}.tar.gz)
-sha1sums=('5960c008c1f4a64c0d31ef11e18d50de4d09d69a')
+sha1sums=('4afd82d9e5c21974a7cbbbcc93a7e00939d49f3c')
 
 build() {
   cd $srcdir/autobuild-${pkgver}
-  python2 setup.py install --root=$pkgdir/ --optimize=1
+
+  sed -i "s|pydot2|pydot|" $srcdir/autobuild-${pkgver}/setup.py
+  python2 setup.py install --root=$srcdir/autobuild-${pkgver}/build --optimize=1
   sed -i -e "s|#![ ]*/usr/bin/python$|#!/usr/bin/python2|" \
          -e "s|#![ ]*/usr/bin/env python$|#!/usr/bin/env python2|" \
-    $(find $pkgdir -name '*.py')
+    $(find $srcdir/autobuild-${pkgver}/build -name '*.py')
+}
+
+package() {
+  cp -a $srcdir/autobuild-${pkgver}/build/usr $pkgdir
 }
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# autobuild-air
+# autobuild-aur
 
 [Autobuild](https://pypi.python.org/pypi/autobuild) python library package for [Arch Linux User Repository](https://aur.archlinux.org/packages/autobuild/)


### PR DESCRIPTION
Several things to note:
* Upgrades `autobuild` from 0.8.12 => 1.0.1
* New dependencies introduced: `python2-pydot` and `llbase`. The official LL `autobuild` package demands a `pydot2` dependency (which there is no Arch package for), but the main difference is that the outdated `pydot2` supports Python 3, which we need not concern ourselves with.
* The `PKGBUILD` follows new guidelines that require `package()` - moreover, manipulating anything in `$pkgdir` is forbidden in the latest `makepkg` versions.
* `python2-distribute` has been deprecated in favor of `python2-setuptools`
* Only packages up the built `usr` directory

Thank you, friend!